### PR TITLE
Removes redundant call to make master track origin/master

### DIFF
--- a/recipes/projects.rb
+++ b/recipes/projects.rb
@@ -40,12 +40,10 @@ node['sprout']['git']['projects'].each do |hash_or_legacy_array|
     end
   end
 
-  ['git branch --set-upstream master origin/master',  'git submodule update --init --recursive'].each do |git_cmd|
-    execute "#{repo_name} - #{git_cmd}" do
-      command git_cmd
-      cwd "#{repo_dir}/#{repo_name}"
-      user node['current_user']
-      not_if { ::File.exist?("#{repo_dir}/#{repo_name}") }
-    end
+  execute "#{repo_name} - git submodule update --init --recursive" do
+    command 'git submodule update --init --recursive'
+    cwd "#{repo_dir}/#{repo_name}"
+    user node['current_user']
+    not_if { ::File.exist?("#{repo_dir}/#{repo_name}") }
   end
 end

--- a/spec/unit/projects_spec.rb
+++ b/spec/unit/projects_spec.rb
@@ -22,11 +22,6 @@ describe 'sprout-git::projects' do
       user: 'fauxhai',
       cwd: '/home/fauxhai/some_workspace'
     )
-    expect(chef_run).to run_execute('git branch --set-upstream master origin/master').with(
-      user: 'fauxhai',
-      cwd: '/home/fauxhai/some_workspace/repo1'
-    )
-
     expect(chef_run).to run_execute('git clone http://example.com/some/repo2 repo2').with(
       user: 'fauxhai',
       cwd: '/home/fauxhai/some_workspace'
@@ -45,10 +40,6 @@ describe 'sprout-git::projects' do
       user: 'fauxhai',
       cwd: '/home/fauxhai/some_workspace'
     )
-    expect(chef_run).to run_execute('git branch --set-upstream master origin/master').with(
-      user: 'fauxhai',
-      cwd: '/home/fauxhai/some_workspace/custom'
-    )
   end
 
   it 'can clone projects into an absolute custom directory' do
@@ -62,10 +53,6 @@ describe 'sprout-git::projects' do
     expect(chef_run).to run_execute('git clone http://example.com/some/repo1.git repo1').with(
       user: 'fauxhai',
       cwd: '/some/non-home-based/workspace'
-    )
-    expect(chef_run).to run_execute('git branch --set-upstream master origin/master').with(
-      user: 'fauxhai',
-      cwd: '/some/non-home-based/workspace/repo1'
     )
   end
 
@@ -83,10 +70,6 @@ describe 'sprout-git::projects' do
     expect(chef_run).to run_execute('git clone http://example.com/some/repo1.git repo1').with(
       user: 'fauxhai',
       cwd: '/home/fauxhai/personal_projects'
-    )
-    expect(chef_run).to run_execute('git branch --set-upstream master origin/master').with(
-      user: 'fauxhai',
-      cwd: '/home/fauxhai/personal_projects/repo1'
     )
   end
 
@@ -161,10 +144,6 @@ describe 'sprout-git::projects' do
     expect(chef_run).to run_execute('git clone http://example.com/some/repo1.git renamed').with(
       user: 'fauxhai',
       cwd: '/home/fauxhai/some_workspace'
-    )
-    expect(chef_run).to run_execute('git branch --set-upstream master origin/master').with(
-      user: 'fauxhai',
-      cwd: '/home/fauxhai/some_workspace/renamed'
     )
   end
 end


### PR DESCRIPTION
Git does that by default unless there is no remote master branch in which case
this command would fail anyway.
tracker:[#74278058] github:[#5]
