### PR TITLE
Only run the post_clone_commands if the repo is freshly cloned

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,35 +18,59 @@ bundle exec soloist
 
 ## Cookbook Usage
 
-### Attributes
+### Recent changes:
 
-#### Recent changes
-the projects attributes have changed from an array of tuples:
+* #### the projects attributes have changed from an array of tuples:
+  ```
+  node_attributes:
+    sprout:
+      git:
+        projects:
+          - # e.g. ~/workspace/foo
+            - foo
+            - https://github.com/pivotal-sprout/sprout-git.git
+  ```
+  to an array of hashes:
 
-```
-node_attributes:
-  sprout:
-    git:
-      projects:
-        - # e.g. ~/workspace/foo
-          - foo
-          - https://github.com/pivotal-sprout/sprout-git.git
-```
+  ```
+  node_attributes:
+    sprout:
+      git:
+        projects:
+          - # e.g. ~/workspace/foo
+            url: https://github.com/pivotal-sprout/sprout-git.git
+            name: foo
+  ```
+  the tuple syntax is deprecated but will continue to work for the near term until enough people have transitioned.  See the Attributes section for more details an the new syntax.
 
-to an array of hashes:
+* #### the projects attributes now include a way to run arbitrary commands on the freshly cloned repo:
+The commands will be run in sequence.  If one of the commands fails (retunrs non-zero) subsequen commands continue to run and the Sprout run is not affected.  Future runs of sprout would not re-run these commands unless the repo was previously deleted. i.e. they only get run on a fresh clone of the project.
 
-```
-node_attributes:
-  sprout:
-    git:
-      projects:
-        - # e.g. ~/workspace/foo
-          url: https://github.com/pivotal-sprout/sprout-git.git
-          name: foo
-```
+  ```
+  node_attributes:
+    sprout:
+      git:
+        projects:
+          - # an example that initializes submodules, installs all gems, sets up the databases, runs rspec, and executes other arbitrary commands even with some failing
+            url: https://github.com/pivotal-sprout/sprout-git.git
+            post_clone_commands:
+              - git submodule update --init
+              - gem install bundler
+              - bundle
+              - rake db:create db:migrate
+              - RAILS_ENV=test rake db:create db:migrate
+              - rake spec
+              - false
+              - echo "I'm still run even though the last command failed"
+  ```
 
-the tuple syntax is deprecated but will continue to work for the near term until enough people have transitioned.  See the Attributes section for more details an the new syntax.
+* #### Projects no longer explicity set master's upstream branch to origin/master
+This is done when the repo is cloned so sprout does not need to explicitly do this.
 
+* #### Projects using the new hash syntax no longer automatically do a `git submodule update --init`
+If the project needs to have submodules initialized then those entries should include the command as a post-clone command.  If the soloistrc is still using the legacy tuple syntax which cannot specify post_clone_commands then we continue to run the submodule update --init on all projects regardless of whether they have submodules.
+
+### Attributes:
 
 *NOTE:* All preferences are namespaced under `sprout => git` they include:
 
@@ -58,11 +82,17 @@ the tuple syntax is deprecated but will continue to work for the near term until
 * `aliases` &mdash; an additional set of custom aliases to be installed in addition to the `base_aliases`. Used by the `aliases` recipe &mdash; default is empty. _see the [soloistrc](soloistrc) or [aliases.rb](attributes/aliases.rb) files for examples._
 * `projects` &mdash; The list of repositories to automatically clone. Used by the `projects` recipe &mdash; this is empty by default see the [soloistrc](soloistrc) or the [attributes/projects.rb](attributes/project.rb) files for examples. it contains an array of project hashes with the following keys:
   * `url` &mdash; ***required*** &mdash; The repo url to clone clone. &mdash; e.g. `https://example.com/some/repo.git`
-  * `name` &mdash; *optional* &mdash; The name of the local folder containing the repo. &mdash; e.g. `my_repo`
+  * `name` &mdash; *optional* &mdash; The name of the local folder containing the repo. &mdash; e.g. `my_repo`  
   * `workspace_path` &mdash; *optional* &mdash; The path to clone into. &mdash; e.g. `~/personal_projects` or `/abs/path/to/personal_projects`
+  * `post_clone_commands` &mdash; *optional* &mdash; A list of commands to run on the freshly cloned repository. Note this is only run on a fresh clone.  Future runs of sprout will not cause these commands to be re-run. &mdash; Some example commands could include: 
+    * `gem install bundler`
+    * `bundle`
+    * `rake db:create:all db:test:prepare default`
+    * `pod install`
+    * `git submodule update --init`
 * `workspace_directory` &mdash; the location under the users home to clone the projects unless otherwise specified by the project config. Used by the `projects` recipe &mdash; default is `'workspace'`
 
-### Recipes
+### Recipes:
 
 * `sprout-git` &mdash; default recipe
 * `sprout-git::aliases` &mdash; installs common git aliases such as `git st`
@@ -120,3 +150,4 @@ bundle
 bundle exec rake spec:integration
 ```
 
+foo

--- a/recipes/projects.rb
+++ b/recipes/projects.rb
@@ -15,6 +15,7 @@ node['sprout']['git']['projects'].each do |hash_or_legacy_array|
     legacy_array = hash_or_legacy_array
     repo_name = legacy_array[0]
     repo_address = legacy_array[1]
+    post_clone_commands << 'git submodule update --init --recursive'
   end
   repo_dir ||= "#{node['sprout']['home']}/#{node['sprout']['git']['workspace_directory']}"
   repo_dir = File.expand_path(repo_dir)
@@ -25,6 +26,7 @@ node['sprout']['git']['projects'].each do |hash_or_legacy_array|
     action :create
     recursive true
   end
+  repo_existed_originally = ::File.exist?("#{repo_dir}/#{repo_name}")
 
   execute "git clone #{repo_address} #{repo_name}" do
     user node['current_user']
@@ -37,13 +39,7 @@ node['sprout']['git']['projects'].each do |hash_or_legacy_array|
       user node['current_user']
       cwd "#{repo_dir}/#{repo_name}"
       ignore_failure true
+      not_if { repo_existed_originally }
     end
-  end
-
-  execute "#{repo_name} - git submodule update --init --recursive" do
-    command 'git submodule update --init --recursive'
-    cwd "#{repo_dir}/#{repo_name}"
-    user node['current_user']
-    not_if { ::File.exist?("#{repo_dir}/#{repo_name}") }
   end
 end

--- a/soloistrc
+++ b/soloistrc
@@ -45,7 +45,7 @@ node_attributes:
           post_clone_commands:
             - 'touch touched.txt'
             - false
-            - 'echo "hello" > world.txt'
+            - 'echo "hello" >> world.txt'
 
         # legacy support
         - # e.g. ~/workspace/foo

--- a/spec/integration/cookbook_spec.rb
+++ b/spec/integration/cookbook_spec.rb
@@ -5,6 +5,7 @@ describe 'sprout-git recipes' do
   before :all do
     expect(`which git-pair`).to be_empty
     expect(system('soloist')).to be_true
+    expect(system('soloist')).to be_true
   end
 
   it 'install: installs git via homebrew' do

--- a/spec/unit/projects_spec.rb
+++ b/spec/unit/projects_spec.rb
@@ -145,5 +145,11 @@ describe 'sprout-git::projects' do
       user: 'fauxhai',
       cwd: '/home/fauxhai/some_workspace'
     )
+
+    expect(chef_run).to run_execute('git submodule update --init --recursive').with(
+      user: 'fauxhai',
+      cwd: '/home/fauxhai/some_workspace/renamed',
+      ignore_failure: true
+    )
   end
 end


### PR DESCRIPTION
Dont run them on future runs of soloist.
- Removes hardcoded 'git submodule update --init' call per repo
  - If still using the legacy project syntax we re-add the submodule update since there is no way for that syntax to define a custom command
  - For anyone using the new project syntax if they have submodules that they want initialized then they need to add a post_clone_command to that project entry
- Updates README.md to show new attribute as well as some example uses.

Tracker:[Finishes #74278058] Github:[Closes #5]
