### PR TITLE
Allow override email addresses for pairs.yml

### DIFF
--- a/spec/integration/cookbook_spec.rb
+++ b/spec/integration/cookbook_spec.rb
@@ -78,6 +78,9 @@ describe 'sprout-git recipes' do
         'prefix' => 'pair',
         'domain' => 'pivotallabs.com'
       },
+      'email_addresses' => {
+        'ah' => 'abhijit@hiremaga.com'
+      },
       'global' => true
     )
   end

--- a/spec/unit/git_scripts_spec.rb
+++ b/spec/unit/git_scripts_spec.rb
@@ -53,6 +53,9 @@ email:
   prefix: lord
   domain: default.example.com
 
+email_addresses:
+  eg: gringo@custom.example.com
+
 global: true
 EOF
     expect(chef_run).to render_file('/home/fauxhai/.pairs').with_content(/#{expected}/)

--- a/templates/default/pairs.yml.erb
+++ b/templates/default/pairs.yml.erb
@@ -9,4 +9,11 @@ email:
   prefix: <%= node['sprout']['git']['prefix'] %>
   domain: <%= node['sprout']['git']['domain'] %>
 
+email_addresses:
+<% node['sprout']['git']['authors'].each do |author| %>
+<% if author['email'] %>
+  <%= "#{author["initials"]}: #{author["email"]}"%>
+<% end %>
+<% end %>
+
 global: true


### PR DESCRIPTION
git-pair now supports override email addresses in the same format as git-duet. This commit uses the same logic to add and email_addresseses section to pairs.yml