### PR TITLE
Fix git-duet tap name to line up with newer brew tap output

### DIFF
--- a/recipes/git_duet.rb
+++ b/recipes/git_duet.rb
@@ -3,6 +3,6 @@ include_recipe 'sprout-git::git_duet_global'
 include_recipe 'sprout-git::git_duet_rotate_authors'
 include_recipe 'sprout-git::authors'
 
-homebrew_tap 'git-duet/homebrew-tap'
+homebrew_tap 'git-duet/tap'
 
 package 'git-duet'

--- a/spec/unit/git_duet_spec.rb
+++ b/spec/unit/git_duet_spec.rb
@@ -25,7 +25,7 @@ describe 'sprout-git::git_duet' do
 
   it 'taps git-duet/homebrew-tap' do
     chef_run.converge(described_recipe)
-    expect(chef_run).to tap_homebrew_tap('git-duet/homebrew-tap')
+    expect(chef_run).to tap_homebrew_tap('git-duet/tap')
   end
 
   it 'brew installs git-duet' do


### PR DESCRIPTION
Brew has recently changed the output of tap from `name-of-tap/homebrew-tap` to `name-of-tap/tap`. This updates git-duet to be in line with this change.