### PR TITLE
Fix leading whitespace issue with git lg alias

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -13,8 +13,7 @@ node.default['sprout']['git']['base_aliases'] = [
   [
     'lg',
     [
-      '"', # open quotes around alias
-      'log',
+      '"log', # open quotes around alias. Included here to avoid a space at the beginning of a line, that breaks git
       '--graph',
       "--pretty=format:'%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset'",
       '--abbrev-commit',


### PR DESCRIPTION
The new attributes way of specifying aliases has broken the 'git lg' alias, as git can't handle the whitespace within the quotes. We get the following error message:

```
Expansion of alias 'lg' failed; '' is not a git command
```

This is fixed by moving the leading quote into the same string as 'log'.