### PR TITLE
Change directory before looking for gitdir

### DIFF
--- a/libraries/git_hooks.rb
+++ b/libraries/git_hooks.rb
@@ -25,11 +25,13 @@ class Chef
       end
 
       def check_and_install_git_hooks(git_file)
-        git_dir = find_git_dir(git_file)
+        ::Dir.chdir(::File.dirname(git_file)) do
+          git_dir = find_git_dir(git_file)
 
-        unless ::Dir.exist?(::File.join(git_dir, 'hooks.old'))
-          copy_recovered_hooks git_file, git_dir
-          install_git_hooks git_file
+          unless ::Dir.exist?(::File.join(git_dir, 'hooks.old'))
+            copy_recovered_hooks git_file, git_dir
+            install_git_hooks git_file
+          end
         end
       end
 


### PR DESCRIPTION
We running sprout not from parent directory.
This is what we see
```
   ================================================================================
      Error executing action `run` on resource 'ruby_block[installing git repo hooks]'
      ================================================================================

      Mixlib::ShellOut::ShellCommandFailed
      ------------------------------------
      Expected process to exit with [0], but received '128'
      ---- Begin output of git rev-parse --resolve-git-dir '/Users/pivotal/go/src/9fans.net/go/.git' ----
      STDOUT:
      STDERR: fatal: Not a git repository (or any of the parent directories): .git
      ---- End output of git rev-parse --resolve-git-dir '/Users/pivotal/go/src/9fans.net/go/.git' ----
      Ran git rev-parse --resolve-git-dir '/Users/pivotal/go/src/9fans.net/go/.git' returned 128
```
I included fix for that.

However, it exposed different problem. I can't run soloist again, cause githooks directory is created in tmp/librarian/cookbooks and it can't be removed.