### PR TITLE
Fixes error downloading tarball for git-script recipe

### DIFF
--- a/recipes/git_scripts.rb
+++ b/recipes/git_scripts.rb
@@ -1,14 +1,15 @@
 include_recipe 'sprout-base::user_owns_usr_local'
 
-tarball_url = 'https://github.com/pivotal/git_scripts/tarball/master'
-src_path = File.join(Chef::Config['file_cache_path'], 'git_scripts.tgz')
-extract_path = '/usr/local/bin'
+checkout_path = "#{Chef::Config['file_cache_path']}/git_scripts"
+installation_path = '/usr/local/bin'
 
-remote_file src_path do
-  source tarball_url
+git checkout_path do
+  repository 'https://github.com/pivotal/git_scripts.git'
+  reference 'master'
+  action :export
 end
 
-execute "tar --strip=2 -xzf #{src_path} -C #{extract_path}" do
+execute "cp #{checkout_path}/bin/* #{installation_path}" do
   user node['sprout']['user']
   not_if 'which git-pair'
 end

--- a/recipes/git_scripts.rb
+++ b/recipes/git_scripts.rb
@@ -9,6 +9,11 @@ git checkout_path do
   action :export
 end
 
+execute "cp -R #{checkout_path}/lib/* #{installation_path}" do
+  user node['sprout']['user']
+  not_if 'which git-pair'
+end
+
 execute "cp #{checkout_path}/bin/* #{installation_path}" do
   user node['sprout']['user']
   not_if 'which git-pair'


### PR DESCRIPTION
system Ruby and OpenSSL that ships with OSX 10.12.x throws an error when talking to Github due to recent changes in Github:

```
ERROR: SSL Error connecting to https://github.com/pivotal/git_scripts/tarball/master
ERROR: SSL Validation failure connecting to host: github.com - SSL_connect returned=1 errno=0 state=SSLv2/v3 read server hello A: tlsv1 alert protocol version
...

    ================================================================================
    Error executing action `create` on resource 'remote_file[/var/chef/cache/git_scripts.tgz]'
    ================================================================================

    OpenSSL::SSL::SSLError
    ----------------------
    SSL Error connecting to https://github.com/pivotal/git_scripts/tarball/master - SSL_connect returned=1 errno=0 state=SSLv2/v3 read server hello A: tlsv1 alert protocol version
```