### PR TITLE
Update cookbook for macOS 10.13

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,5 @@
 AllCops:
+  TargetRubyVersion: 2.3
   Include:
     - Cheffile
     - Gemfile
@@ -12,6 +13,3 @@ SpaceBeforeFirstArg:
 
 LineLength:
   Max: 120
-
-IndentHash:
-  Enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,15 @@
 language: objective-c
-osx_image: xcode7.3
+os: osx
+osx_image: xcode9.3
 rvm: system
 install:
-  - ./sprout exec true # use `exec` to install dependencies
+  # we expect sprout to provide homebrew so we should ensure it isn't present
+  - brew cask list && brew cask uninstall $(brew cask list)
+  - brew      list && brew      uninstall --force --ignore-dependencies $(brew list)
+  - ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/uninstall)" -- --force
+  - rm -rf /usr/local/var/postgres # clear out Travis-installed Postgres 9.4 data
+
+  - for ruby in $(rvm list strings); do rvm uninstall "${ruby}"; done
+  - travis_wait sudo rvm implode --force # We are testing installation of Rubies, so should uninstall everything
 script:
-  - ./sprout exec rake ci
+  - ./sprout exec rake --trace ci

--- a/Cheffile
+++ b/Cheffile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 site 'https://supermarket.getchef.com/api/v1'
 
 cookbook 'homebrew'

--- a/Gemfile
+++ b/Gemfile
@@ -1,20 +1,16 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 gem 'soloist', require: false
 
 group :development do
-  gem 'foodcritic', '< 7.0.0', require: false # foodcritic >=7.0.0 drops support for ruby v2.0.0
-  gem 'rake', require: false
+  gem 'chefspec'
+  gem 'foodcritic'
   gem 'rspec', require: false
   gem 'rubocop', require: false
-  gem 'chefspec', '< 5.0.0', require: false # >=5.0.0 requires ruby v2.1
+
+  gem 'fauxhai', '~> 6.0.0', require: false # versions after 6.0.1 remove `node['etc']`
 end
 
-# Temporarily lock these gems. Newer versions depend on Ruby >= 2.1.0
-# Remove this once https://github.com/mkocher/soloist/issues/39 is closed
-gem 'chef', '~> 12.8.1', require: false
-gem 'chef-zero', '~> 4.5.0', require: false
-gem 'fauxhai', '< 3.7.0', require: false # >=3.7.0 requires ruby v2.1
-gem 'ffi-yajl', '< 2.3.0', require: false # >=2.3.0 requires ruby v2.1
-gem 'ohai', '< 8.18.0', require: false # >=8.18.0 requires ruby v2.2.2
-gem 'rack', '< 2.0.0', require: false # >=2.0.0 requires ruby v2.2.2
+gem 'chef-zero', '~> 13.1', require: false # versions after 14.x require ruby 2.4

--- a/Rakefile
+++ b/Rakefile
@@ -1,13 +1,15 @@
+# frozen_string_literal: true
+
 require 'rake'
 require 'foodcritic'
 require 'rspec/core/rake_task'
 require 'rubocop/rake_task'
 
 desc 'Run foodcritic && rubocop && spec:unit'
-task default: %w(foodcritic rubocop spec:unit)
+task default: %w[foodcritic rubocop spec:unit]
 
 desc 'Run default && spec:integration'
-task ci: %w(default spec:integration)
+task ci: %w[default spec:integration]
 
 FoodCritic::Rake::LintTask.new do |t|
   t.options[:fail_tags] = ['any']

--- a/attributes/authors.rb
+++ b/attributes/authors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 node.default['sprout']['git']['prefix'] = 'pair'
 node.default['sprout']['git']['domain'] = 'example.com'
 node.default['sprout']['git']['authors'] = [

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 node.default['sprout']['git']['aliases'] = [
   # a space delimited string containing the alias-name and alias-value
 ]

--- a/attributes/git_duet.rb
+++ b/attributes/git_duet.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 node.default['sprout']['git']['git_duet'] = {
   'config' => {
     # see: https://github.com/git-duet/git-duet

--- a/attributes/git_hooks_core.rb
+++ b/attributes/git_hooks_core.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 include_attribute 'sprout-base::home'
 include_attribute 'sprout-base::workspace_directory'
 

--- a/attributes/projects.rb
+++ b/attributes/projects.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 node.default['sprout']['git']['projects_settings'] = {
   # recursive: true,
 }

--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 if defined?(ChefSpec)
   ChefSpec.define_matcher(:sprout_git_config)
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,3 +1,6 @@
+# frozen_string_literal: true
+
+chef_version     '>= 12.6.0'
 name             'sprout-git'
 maintainer       'Pivotal'
 maintainer_email 'sprout-maintainers@googlegroups.com'
@@ -6,7 +9,7 @@ issues_url       'https://github.com/pivotal-sprout/sprout-git/issues'
 license          'MIT'
 description      'Installs/Configures sprout-git'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.3.1'
+version          '0.4.0'
 supports         'mac_os_x'
 depends          'sprout-base'
 depends          'homebrew'

--- a/recipes/aliases.rb
+++ b/recipes/aliases.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 include_recipe 'sprout-git::install'
 
 aliases = node['sprout']['git']['aliases'] + node['sprout']['git']['base_aliases']

--- a/recipes/authors.rb
+++ b/recipes/authors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Manage a .git-authors file as expected by https://github.com/modcloth/git-duet
 
 template "#{node['sprout']['home']}/.git-authors" do

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 include_recipe 'sprout-git::install'
 include_recipe 'sprout-git::aliases'
 include_recipe 'sprout-git::global_config'

--- a/recipes/default_editor.rb
+++ b/recipes/default_editor.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 include_recipe 'sprout-base::bash_it'
 
 sprout_base_bash_it_custom_plugin 'bash_it/custom/git-export_editor.bash' do

--- a/recipes/git_duet.rb
+++ b/recipes/git_duet.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 include_recipe 'homebrew'
 include_recipe 'sprout-git::git_duet_global'
 include_recipe 'sprout-git::git_duet_rotate_authors'

--- a/recipes/git_duet_global.rb
+++ b/recipes/git_duet_global.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 include_recipe 'sprout-base::bash_it'
 
 sprout_base_bash_it_custom_plugin 'bash_it/custom/git-duet_global.bash'

--- a/recipes/git_duet_rotate_authors.rb
+++ b/recipes/git_duet_rotate_authors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 include_recipe 'sprout-base::bash_it'
 
 sprout_base_bash_it_custom_plugin 'bash_it/custom/git-duet_rotate_authors.bash'

--- a/recipes/git_hooks.rb
+++ b/recipes/git_hooks.rb
@@ -1,28 +1,30 @@
-Chef::Log.warn(<<-EOF)
-The sprout-git::git_hooks recipe is now DEPRECATED!
+# frozen_string_literal: true
 
-Git 2.9 added new configuration options that made the configuration of hooks far
-simpler. This is now the recommended way to add git hooks. At the same time we
-have made our own credential scanner which we are going to distribute separately
-from sprout-git.
+Chef::Log.warn(<<~GIT_HOOKS_WARNING)
+  The sprout-git::git_hooks recipe is now DEPRECATED!
 
-The new configuration options are used in the new sprout-git::git_hooks_core
-recipe. It provides a more opinionated but far less complex method of installing
-system-wide git hooks.
+  Git 2.9 added new configuration options that made the configuration of hooks far
+  simpler. This is now the recommended way to add git hooks. At the same time we
+  have made our own credential scanner which we are going to distribute separately
+  from sprout-git.
 
-You can remove the existing git hooks by deleting the following directories.
-Make sure that you have backed up any custom hooks that you would like to keep!
+  The new configuration options are used in the new sprout-git::git_hooks_core
+  recipe. It provides a more opinionated but far less complex method of installing
+  system-wide git hooks.
 
-* /usr/local/share/githooks
-* $HOME/.githooks
-* [YOUR_PROJECTS...]/githooks
+  You can remove the existing git hooks by deleting the following directories.
+  Make sure that you have backed up any custom hooks that you would like to keep!
 
-Or, if you trust us, (please review the script for safety anyway) you can run
-the script linked below which will remove the default hooks that were added and
-warn about any custom hooks that should be backed up and migrated.
+  * /usr/local/share/githooks
+  * $HOME/.githooks
+  * [YOUR_PROJECTS...]/githooks
 
-  https://github.com/pivotal-sprout/sprout-git/blob/master/share/remove_git_hooks.sh
+  Or, if you trust us, (please review the script for safety anyway) you can run
+  the script linked below which will remove the default hooks that were added and
+  warn about any custom hooks that should be backed up and migrated.
 
-We're sorry for any inconvenience but we hope you'll like the far simpler new
-approach.
-EOF
+    https://github.com/pivotal-sprout/sprout-git/blob/master/share/remove_git_hooks.sh
+
+  We're sorry for any inconvenience but we hope you'll like the far simpler new
+  approach.
+GIT_HOOKS_WARNING

--- a/recipes/git_hooks_core.rb
+++ b/recipes/git_hooks_core.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 include_recipe 'sprout-git::install'
 
 hooks_repository = node['sprout']['git']['hooks']['repository']

--- a/recipes/git_scripts.rb
+++ b/recipes/git_scripts.rb
@@ -1,4 +1,4 @@
-include_recipe 'sprout-base::user_owns_usr_local'
+# frozen_string_literal: true
 
 tarball_url = 'https://github.com/pivotal/git_scripts/tarball/master'
 src_path = File.join(Chef::Config['file_cache_path'], 'git_scripts.tgz')

--- a/recipes/git_secrets.rb
+++ b/recipes/git_secrets.rb
@@ -1,28 +1,30 @@
-Chef::Log.warn(<<-EOF)
-The sprout-git::git_secrets recipe is now DEPRECATED!
+# frozen_string_literal: true
 
-Git 2.9 added new configuration options that made the configuration of hooks far
-simpler. This is now the recommended way to add git hooks. At the same time we
-have made our own credential scanner which we are going to distribute separately
-from sprout-git.
+Chef::Log.warn(<<~GIT_SECRETS_WARNING)
+  The sprout-git::git_secrets recipe is now DEPRECATED!
 
-The new configuration options are used in the new sprout-git::git_hooks_core
-recipe. It provides a more opinionated but far less complex method of installing
-system-wide git hooks.
+  Git 2.9 added new configuration options that made the configuration of hooks far
+  simpler. This is now the recommended way to add git hooks. At the same time we
+  have made our own credential scanner which we are going to distribute separately
+  from sprout-git.
 
-You can remove the existing git hooks by deleting the following directories.
-Make sure that you have backed up any custom hooks that you would like to keep!
+  The new configuration options are used in the new sprout-git::git_hooks_core
+  recipe. It provides a more opinionated but far less complex method of installing
+  system-wide git hooks.
 
-* /usr/local/share/githooks
-* $HOME/.githooks
-* [YOUR_PROJECTS...]/githooks
+  You can remove the existing git hooks by deleting the following directories.
+  Make sure that you have backed up any custom hooks that you would like to keep!
 
-Or, if you trust us, (please review the script for safety anyway) you can run
-the script linked below which will remove the default hooks that were added and
-warn about any custom hooks that should be backed up and migrated.
+  * /usr/local/share/githooks
+  * $HOME/.githooks
+  * [YOUR_PROJECTS...]/githooks
 
-  https://github.com/pivotal-sprout/sprout-git/blob/master/share/remove_git_hooks.sh
+  Or, if you trust us, (please review the script for safety anyway) you can run
+  the script linked below which will remove the default hooks that were added and
+  warn about any custom hooks that should be backed up and migrated.
 
-We're sorry for any inconvenience but we hope you'll like the far simpler new
-approach.
-EOF
+    https://github.com/pivotal-sprout/sprout-git/blob/master/share/remove_git_hooks.sh
+
+  We're sorry for any inconvenience but we hope you'll like the far simpler new
+  approach.
+GIT_SECRETS_WARNING

--- a/recipes/global_config.rb
+++ b/recipes/global_config.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 include_recipe 'sprout-git::install'
 
 node['sprout']['git']['global_config'].each_pair do |setting, value|

--- a/recipes/global_ignore.rb
+++ b/recipes/global_ignore.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 template "#{node['sprout']['home']}/.gitignore_global" do
   source 'gitignore_global.erb'
   owner node['sprout']['user']

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 include_recipe 'homebrew'
 
 # Explicitly choose a unique resource name to avoid warnings

--- a/recipes/projects.rb
+++ b/recipes/projects.rb
@@ -1,9 +1,12 @@
+# frozen_string_literal: true
+
 # Recipe to clone git repositories into the users workspace_directory
 # look at soloistrc for example
 
 include_recipe 'sprout-base::workspace_directory'
 
 settings_hash = node['sprout']['git']['projects_settings']
+# rubocop:disable Metrics/BlockLength
 node['sprout']['git']['projects'].each do |project_hash|
   if project_hash['url']
     repo_address = project_hash['url']
@@ -68,3 +71,4 @@ node['sprout']['git']['projects'].each do |project_hash|
     end
   end
 end
+# rubocop:enable Metrics/BlockLength

--- a/resources/config.rb
+++ b/resources/config.rb
@@ -1,7 +1,9 @@
-property :setting_key, String, name_attribute: true
+# frozen_string_literal: true
+
+property :setting_key, String, name_property: true
 property :setting_value, String
 property :setting_owner, String, default: node['sprout']['user']
-property :scope, is: [:system, :global], default: :global
+property :scope, is: %i[system global], default: :global
 
 default_action :create
 

--- a/resources/install_git_hooks.rb
+++ b/resources/install_git_hooks.rb
@@ -1,4 +1,6 @@
-property :search_dir, String, name_attribute: true
+# frozen_string_literal: true
+
+property :search_dir, String, name_property: true
 
 property :user, String, default: node['sprout']['user']
 

--- a/spec/integration/cookbook_spec.rb
+++ b/spec/integration/cookbook_spec.rb
@@ -1,7 +1,10 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'yaml'
 
-describe 'sprout-git recipes' do
+# rubocop:disable Metrics/BlockLength
+RSpec.describe 'sprout-git recipes' do
   before :all do
     expect(File).not_to exist('/usr/local/bin/git-pair')
     `mkdir -p ~/workspace`
@@ -118,3 +121,4 @@ describe 'sprout-git recipes' do
     verify_cloned_project('~/workspace/old-git-repo')
   end
 end
+# rubocop:enable Metrics/BlockLength

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,10 @@
+# frozen_string_literal: true
+
 require 'rspec'
 
 RSpec.configure do |config|
+  config.disable_monkey_patching!
+
   config.run_all_when_everything_filtered = true
   config.filter_run :focus
 end

--- a/spec/unit/aliases_spec.rb
+++ b/spec/unit/aliases_spec.rb
@@ -1,13 +1,16 @@
+# frozen_string_literal: true
+
 require 'unit/spec_helper'
 
-describe 'sprout-git::aliases' do
+# rubocop:disable Metrics/BlockLength
+RSpec.describe 'sprout-git::aliases' do
   let(:chef_run) { ChefSpec::SoloRunner.new }
   let(:foo_missing) { true }
   let(:custom_aliases) { [] }
 
   before do
     stub_command('which git').and_return(true)
-    chef_run.node.set['sprout']['git']['base_aliases'] = ['foo "bar baz"', 'bar "baz bat"']
+    chef_run.node.override['sprout']['git']['base_aliases'] = ['foo "bar baz"', 'bar "baz bat"']
   end
 
   it 'includes the install recipe' do
@@ -22,7 +25,7 @@ describe 'sprout-git::aliases' do
 
   context 'with custom aliases defined as well' do
     before do
-      chef_run.node.set['sprout']['git']['aliases'] = ['one custom', 'other custom']
+      chef_run.node.override['sprout']['git']['aliases'] = ['one custom', 'other custom']
     end
 
     it 'installs the custom aliases as well' do
@@ -34,3 +37,4 @@ describe 'sprout-git::aliases' do
     end
   end
 end
+# rubocop:enable Metrics/BlockLength

--- a/spec/unit/authors_spec.rb
+++ b/spec/unit/authors_spec.rb
@@ -1,19 +1,22 @@
+# frozen_string_literal: true
+
 require 'unit/spec_helper'
 
-describe 'sprout-git::authors' do
+RSpec.describe 'sprout-git::authors' do
   let(:chef_run) { ChefSpec::SoloRunner.new }
 
   it 'installs a template in ~/.git-authors' do
-    chef_run.node.set['sprout']['git']['authors'] = [
+    chef_run.node.override['sprout']['git']['authors'] = [
       { initials: 'eg', name: 'El Gringo', email: 'gringo@custom.example.com' },
       { initials: 'hh', name: 'Hagar the Horrible' },
       { initials: 'lg', name: 'Lady Godiva', username: 'lgodiva' }
     ]
-    chef_run.node.set['sprout']['git']['domain'] = 'default.example.com'
-    chef_run.node.set['sprout']['git']['prefix'] = 'unused'
+    chef_run.node.override['sprout']['git']['domain'] = 'default.example.com'
+    chef_run.node.override['sprout']['git']['prefix'] = 'unused'
 
     chef_run.converge(described_recipe)
-    expected = <<-EOF
+    # rubocop:disable Layout/IndentHeredoc
+    expected_git_authors = <<-GIT_AUTHORS
 authors:
   eg: El Gringo
   hh: Hagar the Horrible
@@ -22,7 +25,8 @@ email:
   domain: default.example.com
 email_addresses:
   eg: gringo@custom.example.com
-EOF
-    expect(chef_run).to render_file('/home/fauxhai/.git-authors').with_content(/#{expected}/)
+GIT_AUTHORS
+    # rubocop:enable Layout/IndentHeredoc
+    expect(chef_run).to render_file('/home/fauxhai/.git-authors').with_content(/#{expected_git_authors}/)
   end
 end

--- a/spec/unit/default_editor_spec.rb
+++ b/spec/unit/default_editor_spec.rb
@@ -1,6 +1,8 @@
+# frozen_string_literal: true
+
 require 'unit/spec_helper'
 
-describe 'sprout-git::default_editor' do
+RSpec.describe 'sprout-git::default_editor' do
   let(:chef_run) { ChefSpec::SoloRunner.new }
 
   it 'includes sprout-base::bash_it' do

--- a/spec/unit/default_spec.rb
+++ b/spec/unit/default_spec.rb
@@ -1,6 +1,8 @@
+# frozen_string_literal: true
+
 require 'unit/spec_helper'
 
-describe 'sprout-git::default' do
+RSpec.describe 'sprout-git::default' do
   let(:runner) { ChefSpec::SoloRunner.new }
   before do
     stub_command('which git').and_return(true)

--- a/spec/unit/git_duet_global_spec.rb
+++ b/spec/unit/git_duet_global_spec.rb
@@ -1,6 +1,8 @@
+# frozen_string_literal: true
+
 require 'unit/spec_helper'
 
-describe 'sprout-git::git_duet_global' do
+RSpec.describe 'sprout-git::git_duet_global' do
   let(:chef_run) { ChefSpec::SoloRunner.new }
 
   it 'includes sprout-base::bash_it' do

--- a/spec/unit/git_duet_rotate_authors_spec.rb
+++ b/spec/unit/git_duet_rotate_authors_spec.rb
@@ -1,6 +1,8 @@
+# frozen_string_literal: true
+
 require 'unit/spec_helper'
 
-describe 'sprout-git::git_duet_rotate_authors' do
+RSpec.describe 'sprout-git::git_duet_rotate_authors' do
   let(:chef_run) { ChefSpec::SoloRunner.new }
 
   it 'includes sprout-base::bash_it' do

--- a/spec/unit/git_duet_spec.rb
+++ b/spec/unit/git_duet_spec.rb
@@ -1,6 +1,9 @@
+# frozen_string_literal: true
+
 require 'unit/spec_helper'
 
-describe 'sprout-git::git_duet' do
+# rubocop:disable Metrics/BlockLength
+RSpec.describe 'sprout-git::git_duet' do
   let(:chef_run) { ChefSpec::SoloRunner.new }
 
   before do
@@ -37,3 +40,4 @@ describe 'sprout-git::git_duet' do
     expect(chef_run).to install_package('git-duet')
   end
 end
+# rubocop:enable Metrics/BlockLength

--- a/spec/unit/git_hooks_core_spec.rb
+++ b/spec/unit/git_hooks_core_spec.rb
@@ -1,5 +1,8 @@
+# frozen_string_literal: true
+
 require 'unit/spec_helper'
 
+# rubocop:disable Metrics/BlockLength
 RSpec.describe 'sprout-git::git_hooks_core' do
   let(:runner) { ChefSpec::SoloRunner.new }
   let(:hooks_dir) do
@@ -41,7 +44,7 @@ RSpec.describe 'sprout-git::git_hooks_core' do
 
   context 'when hooks > repository is set' do
     before do
-      runner.node.set['sprout']['git']['hooks']['repository'] = 'https://git.example.com'
+      runner.node.override['sprout']['git']['hooks']['repository'] = 'https://git.example.com'
     end
 
     context 'with no revision' do
@@ -83,8 +86,8 @@ RSpec.describe 'sprout-git::git_hooks_core' do
 
     context 'with a revision' do
       before do
-        runner.node.set['sprout']['git']['hooks']['repository'] = 'https://git.example.com'
-        runner.node.set['sprout']['git']['hooks']['revision'] = 'example-branch'
+        runner.node.override['sprout']['git']['hooks']['repository'] = 'https://git.example.com'
+        runner.node.override['sprout']['git']['hooks']['revision'] = 'example-branch'
 
         runner.converge(described_recipe)
       end
@@ -122,3 +125,4 @@ RSpec.describe 'sprout-git::git_hooks_core' do
     end
   end
 end
+# rubocop:enable Metrics/BlockLength

--- a/spec/unit/git_scripts_spec.rb
+++ b/spec/unit/git_scripts_spec.rb
@@ -1,17 +1,15 @@
+# frozen_string_literal: true
+
 require 'unit/spec_helper'
 
-describe 'sprout-git::git_scripts' do
+# rubocop:disable Metrics/BlockLength
+RSpec.describe 'sprout-git::git_scripts' do
   let(:chef_run) { ChefSpec::SoloRunner.new }
   let(:which_pair) { nil }
   let(:untar_command) do
     'tar --strip=2 -xzf /var/chef/cache/git_scripts.tgz -C /usr/local/bin'
   end
   before { stub_command('which git-pair').and_return(which_pair) }
-
-  it 'includes sprout-base::user_owns_usr_local' do
-    chef_run.converge(described_recipe)
-    expect(chef_run).to include_recipe('sprout-base::user_owns_usr_local')
-  end
 
   it 'downloads git_scripts as a tarball' do
     chef_run.converge(described_recipe)
@@ -35,15 +33,16 @@ describe 'sprout-git::git_scripts' do
   end
 
   it 'installs a template in ~/.pairs' do
-    chef_run.node.set['sprout']['git']['authors'] = [
+    chef_run.node.override['sprout']['git']['authors'] = [
       { initials: 'eg', name: 'El Gringo', email: 'gringo@custom.example.com' },
       { initials: 'hh', name: 'Hagar the Horrible' },
       { initials: 'lg', name: 'Lady Godiva', username: 'lgodiva' }
     ]
-    chef_run.node.set['sprout']['git']['domain'] = 'default.example.com'
-    chef_run.node.set['sprout']['git']['prefix'] = 'lord'
+    chef_run.node.override['sprout']['git']['domain'] = 'default.example.com'
+    chef_run.node.override['sprout']['git']['prefix'] = 'lord'
     chef_run.converge(described_recipe)
-    expected = <<-EOF
+    # rubocop:disable Layout/IndentHeredoc
+    expected_git_pairs = <<-EXPECTED_GIT_PAIRS
 pairs:
   eg: El Gringo
   hh: Hagar the Horrible
@@ -57,8 +56,9 @@ email_addresses:
   eg: gringo@custom.example.com
 
 global: true
-EOF
-    expect(chef_run).to render_file('/home/fauxhai/.pairs').with_content(/#{expected}/)
+EXPECTED_GIT_PAIRS
+    # rubocop:enable Layout/IndentHeredoc
+    expect(chef_run).to render_file('/home/fauxhai/.pairs').with_content(/#{expected_git_pairs}/)
   end
 
   it 'overwrites the pairs file if it already exists' do
@@ -67,3 +67,4 @@ EOF
     expect(chef_run).to_not create_template_if_missing('/home/fauxhai/.pairs')
   end
 end
+# rubocop:enable Metrics/BlockLength

--- a/spec/unit/projects_spec.rb
+++ b/spec/unit/projects_spec.rb
@@ -1,10 +1,13 @@
+# frozen_string_literal: true
+
 require 'unit/spec_helper'
 
-describe 'sprout-git::projects' do
+# rubocop:disable Metrics/BlockLength
+RSpec.describe 'sprout-git::projects' do
   let(:chef_run) { ChefSpec::SoloRunner.new }
   let(:repo_base_url) { 'http://example.com/some/repo' }
   before do
-    chef_run.node.set['workspace_directory'] = 'some_workspace'
+    chef_run.node.override['workspace_directory'] = 'some_workspace'
   end
 
   it 'includes sprout-base::workspace_directory' do
@@ -13,7 +16,7 @@ describe 'sprout-git::projects' do
   end
 
   it 'can clone projects with only the url specified' do
-    chef_run.node.set['sprout']['git']['projects'] = [
+    chef_run.node.override['sprout']['git']['projects'] = [
       { 'url' => "#{repo_base_url}1.git" },
       { 'url' => "#{repo_base_url}2" }
     ]
@@ -29,7 +32,7 @@ describe 'sprout-git::projects' do
   end
 
   it 'can clone projects with a custom name if specified' do
-    chef_run.node.set['sprout']['git']['projects'] = [
+    chef_run.node.override['sprout']['git']['projects'] = [
       {
         'url' => "#{repo_base_url}1.git",
         'name' => 'custom'
@@ -43,7 +46,7 @@ describe 'sprout-git::projects' do
   end
 
   it 'can clone from github using github key instead of url' do
-    chef_run.node.set['sprout']['git']['projects'] = [
+    chef_run.node.override['sprout']['git']['projects'] = [
       { 'github' => 'foo/bar' },
       { 'github' => 'baz/bat', 'name' => 'my_bat', 'branch' => 'other' }
     ]
@@ -59,7 +62,7 @@ describe 'sprout-git::projects' do
   end
 
   it 'can clone using --recursive per project' do
-    chef_run.node.set['sprout']['git']['projects'] = [
+    chef_run.node.override['sprout']['git']['projects'] = [
       { 'github' => 'foo/bar', 'recursive' => true },
       { 'github' => 'baz/bat', 'recursive' => true, 'name' => 'my_bat', 'branch' => 'other' }
     ]
@@ -75,8 +78,8 @@ describe 'sprout-git::projects' do
   end
 
   it 'can clone using --recursive for all projectcs' do
-    chef_run.node.set['sprout']['git']['projects_settings'] = { 'recursive' => true }
-    chef_run.node.set['sprout']['git']['projects'] = [
+    chef_run.node.override['sprout']['git']['projects_settings'] = { 'recursive' => true }
+    chef_run.node.override['sprout']['git']['projects'] = [
       { 'github' => 'foo/bar' },
       { 'github' => 'quick/quack', 'recursive' => false },
       { 'github' => 'baz/bat', 'name' => 'my_bat', 'branch' => 'other' }
@@ -97,7 +100,7 @@ describe 'sprout-git::projects' do
   end
 
   it 'can clone custom branch of project if specified' do
-    chef_run.node.set['sprout']['git']['projects'] = [
+    chef_run.node.override['sprout']['git']['projects'] = [
       {
         'url' => "#{repo_base_url}1.git",
         'branch' => 'develop'
@@ -111,7 +114,7 @@ describe 'sprout-git::projects' do
   end
 
   it 'can clone projects into an absolute custom directory' do
-    chef_run.node.set['sprout']['git']['projects'] = [
+    chef_run.node.override['sprout']['git']['projects'] = [
       {
         'url' => "#{repo_base_url}1.git",
         'workspace_path' => '/some/non-home-based/workspace'
@@ -125,7 +128,7 @@ describe 'sprout-git::projects' do
   end
 
   it 'can clone projects into a relative custom directory' do
-    chef_run.node.set['sprout']['git']['projects'] = [
+    chef_run.node.override['sprout']['git']['projects'] = [
       {
         'url' => "#{repo_base_url}1.git",
         'workspace_path' => '~/personal_projects'
@@ -142,7 +145,7 @@ describe 'sprout-git::projects' do
   end
 
   it 'does not clone the repo if it already exists' do
-    chef_run.node.set['sprout']['git']['projects'] = [
+    chef_run.node.override['sprout']['git']['projects'] = [
       { 'url' => "#{repo_base_url}1.git" },
       { 'url' => "#{repo_base_url}2" }
     ]
@@ -154,7 +157,7 @@ describe 'sprout-git::projects' do
   end
 
   it 'creates the workspace if it is missing' do
-    chef_run.node.set['sprout']['git']['projects'] = [
+    chef_run.node.override['sprout']['git']['projects'] = [
       { 'url' => "#{repo_base_url}1.git" },
       {
         'url' => "#{repo_base_url}3.git",
@@ -174,7 +177,7 @@ describe 'sprout-git::projects' do
   end
 
   it 'execute post-clone commands' do
-    chef_run.node.set['sprout']['git']['projects'] = [
+    chef_run.node.override['sprout']['git']['projects'] = [
       {
         'url' => "#{repo_base_url}1.git",
         'post_clone_commands' => [
@@ -204,7 +207,7 @@ describe 'sprout-git::projects' do
   end
 
   it 'can update projects that were previously checked out' do
-    chef_run.node.set['sprout']['git']['projects'] = [
+    chef_run.node.override['sprout']['git']['projects'] = [
       {
         'url' => "#{repo_base_url}1.git",
         'update' => true
@@ -221,3 +224,4 @@ describe 'sprout-git::projects' do
     )
   end
 end
+# rubocop:enable Metrics/BlockLength

--- a/spec/unit/spec_helper.rb
+++ b/spec/unit/spec_helper.rb
@@ -1,11 +1,16 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'chefspec'
 require 'chefspec/librarian'
 
 RSpec.configure do |config|
   config.platform = 'mac_os_x'
-  config.version = '10.11.1' # via https://github.com/customink/fauxhai/tree/master/lib/fauxhai/platforms/mac_os_x
-  config.before { stub_const('ENV', 'SUDO_USER' => 'fauxhai') }
+  config.version = '10.13' # via https://github.com/customink/fauxhai/tree/master/lib/fauxhai/platforms/mac_os_x/
+  config.before do
+    stub_const('ENV', 'SUDO_USER' => 'fauxhai')
+    stub_command('which git').and_return(true)
+  end
   config.after(:suite) { FileUtils.rm_r('.librarian') }
   config.file_cache_path = '/var/chef/cache'
 end

--- a/sprout
+++ b/sprout
@@ -3,15 +3,16 @@
 set -e
 
 function use_local_gems() {
+  local system_ruby_bin="/System/Library/Frameworks/Ruby.framework/Versions/Current/usr/bin/"
   SPROUT_HOME="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
   export SPROUT_HOME
-  export GEM_HOME="${SPROUT_HOME}/tmp/ruby/2.0.0"
+  export GEM_HOME="${SPROUT_HOME}/tmp/ruby/2.3.0"
   export GEM_PATH="${GEM_HOME}"
-  export PATH="${GEM_HOME}/bin:/usr/local/bin:/usr/bin:/bin:/usr/local/sbin:/usr/sbin:/sbin"
+  export PATH="${GEM_HOME}/bin:${system_ruby_bin}:/usr/local/bin:/usr/bin:/bin:/usr/local/sbin:/usr/sbin:/sbin"
 
   current_ruby=$(which ruby)
-  if [ "${current_ruby}" != '/usr/bin/ruby' ]; then
-    echo -e "\033[31mWarning: sprout should be run with system ruby; using '${current_ruby}'\033[0m"
+  if [ "${current_ruby}" != "${system_ruby_bin}/ruby" ]; then
+    echo -e "\\033[31mWarning: sprout should be run with system ruby; using '${current_ruby}'\\033[0m"
   fi
   echo "# - Using $(${current_ruby} -v)"
 }


### PR DESCRIPTION
- update `sprout` script
- update Travis config
- fix foodcritic and rubocop errors
- remove most gem version restrictions
  - lock fauxhai to `~> 6.0.0`, later versions remove `node['etc']` which we rely on
    - this is apparently a chef v14 change
  - lock chef-zero to `~> 13.1`, later versions require ruby 2.4